### PR TITLE
lh use PIP 45 config for zk test

### DIFF
--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -62,6 +62,8 @@ if [[ "$UPGRADE_FROM_VERSION" != "" ]]; then
     install_type="upgrade"
     echo "Wait 10 seconds"
     sleep 10
+    # check pulsar environment
+    ci::check_pulsar_environment
     # test that we can access the admin api
     ci::test_pulsar_admin_api_access
     # produce messages with old version of pulsar and consume with new version

--- a/.ci/clusters/values-prometheus-grafana.yaml
+++ b/.ci/clusters/values-prometheus-grafana.yaml
@@ -19,6 +19,8 @@
 
 kube-prometheus-stack:
   enabled: true
+  prometheusOperator:
+    enabled: true
   prometheus:
     enabled: true
   grafana:

--- a/.ci/configure_ci_runner_for_debugging.sh
+++ b/.ci/configure_ci_runner_for_debugging.sh
@@ -27,7 +27,7 @@ function k9s() {
     # install k9s on the fly
     if [ ! -x /usr/local/bin/k9s ]; then
         echo "Installing k9s..."
-        curl -L -s https://github.com/derailed/k9s/releases/download/v0.32.5/k9s_Linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin k9s
+        curl -L -s https://github.com/derailed/k9s/releases/download/v0.40.5/k9s_Linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin k9s
     fi
     command k9s "$@"
 }

--- a/.ci/values-common.yaml
+++ b/.ci/values-common.yaml
@@ -55,6 +55,12 @@ bookkeeper:
     diskUsageWarnThreshold: "0.999"
     PULSAR_PREFIX_diskUsageThreshold: "0.999"
     PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
+    # minimal memory use for bookkeeper
+    # https://bookkeeper.apache.org/docs/reference/config#db-ledger-storage-settings
+    dbStorage_writeCacheMaxSizeMb: "32"
+    dbStorage_readAheadCacheMaxSizeMb: "32"
+    dbStorage_rocksDB_writeBufferSizeMB: "8"
+    dbStorage_rocksDB_blockCacheSize: "8388608"    
 
 broker:
   replicaCount: 1

--- a/.github/workflows/pulsar-helm-chart-ci.yaml
+++ b/.github/workflows/pulsar-helm-chart-ci.yaml
@@ -187,81 +187,11 @@ jobs:
         k8sVersion:
           - version: "1.23.17"
             kind_image_tag: v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
-          - version: "1.29.2"
-            kind_image_tag: v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245
         testScenario:
           - name: Upgrade latest released version
             values_file: .ci/clusters/values-upgrade.yaml
             shortname: upgrade
             type: upgrade
-          - name: Use previous LTS Pulsar Image
-            values_file: .ci/clusters/values-pulsar-previous-lts.yaml
-            shortname: pulsar-previous-lts
-          - name: JWT Asymmetric Keys
-            values_file: .ci/clusters/values-jwt-asymmetric.yaml
-            shortname: jwt-asymmetric
-          - name: JWT Symmetric Key
-            values_file: .ci/clusters/values-jwt-symmetric.yaml
-            shortname: jwt-symmetric
-          - name: TLS
-            values_file: .ci/clusters/values-tls.yaml
-            shortname: tls
-          - name: Broker & Proxy TLS
-            values_file: .ci/clusters/values-broker-tls.yaml
-            shortname: broker-tls
-          - name: BK TLS Only
-            values_file: .ci/clusters/values-bk-tls.yaml
-            shortname: bk-tls
-          - name: ZK TLS Only
-            values_file: .ci/clusters/values-zk-tls.yaml
-            shortname: zk-tls
-          - name: ZK & BK TLS Only
-            values_file: .ci/clusters/values-zkbk-tls.yaml
-            shortname: zkbk-tls
-          - name: PSP
-            values_file: .ci/clusters/values-psp.yaml
-            shortname: psp
-          - name: Pulsar Manager
-            values_file: .ci/clusters/values-pulsar-manager.yaml
-            shortname: pulsar-manager
-          - name: Oxia
-            values_file: .ci/clusters/values-oxia.yaml
-            shortname: oxia
-        include:
-          - k8sVersion:
-              version: "1.23.17"
-              kind_image_tag: v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
-            testScenario:
-              name: "Upgrade TLS"
-              values_file: .ci/clusters/values-tls.yaml
-              shortname: tls
-              type: upgrade
-          - k8sVersion:
-              version: "1.23.17"
-              kind_image_tag: v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
-            testScenario:
-              name: "Upgrade PSP"
-              values_file: .ci/clusters/values-psp.yaml
-              shortname: psp
-              type: upgrade
-          - k8sVersion:
-              version: "1.23.17"
-              kind_image_tag: v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
-            testScenario:
-              name: "Upgrade kube-prometheus-stack for previous LTS"
-              values_file: .ci/clusters/values-prometheus-grafana.yaml --values .ci/clusters/values-pulsar-previous-lts.yaml
-              shortname: prometheus-grafana
-              type: upgrade
-              upgradeFromVersion: 3.2.0
-          - k8sVersion:
-              version: "1.23.17"
-              kind_image_tag: v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3
-            testScenario:
-              name: "TLS with helm 3.12.0"
-              values_file: .ci/clusters/values-tls.yaml
-              shortname: tls
-              type: install
-            helmVersion: 3.12.0
     env:
       k8sVersion: ${{ matrix.k8sVersion.kind_image_tag }}
       KUBECTL_VERSION: ${{ matrix.k8sVersion.version }}

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -98,8 +98,12 @@ Define bookie common config
 */}}
 {{- define "pulsar.bookkeeper.config.common" -}}
 {{- if .Values.components.zookeeper }}
+{{- if .Values.usePulsarMetadataBookieDriver }}
+metadataServiceUri: "metadata-store:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+{{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+{{- end }}
 {{- else if .Values.components.oxia }}
 metadataServiceUri: "{{ template "pulsar.oxia.metadata.url.bookkeeper" . }}"
 {{- end }}

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -99,7 +99,8 @@ Define bookie common config
 {{- define "pulsar.bookkeeper.config.common" -}}
 {{- if .Values.components.zookeeper }}
 {{- if (and (hasKey .Values.pulsar_metadata "bookkeeper") .Values.pulsar_metadata.bookkeeper.usePulsarMetadataBookieDriver) }}
-metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+zkLedgersRootPath: "/ledgers"
 {{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -99,7 +99,7 @@ Define bookie common config
 {{- define "pulsar.bookkeeper.config.common" -}}
 {{- if .Values.components.zookeeper }}
 {{- if .Values.usePulsarMetadataBookieDriver }}
-metadataServiceUri: "metadata-store:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
 {{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -99,8 +99,9 @@ Define bookie common config
 {{- define "pulsar.bookkeeper.config.common" -}}
 {{- if .Values.components.zookeeper }}
 {{- if (and (hasKey .Values.pulsar_metadata "bookkeeper") .Values.pulsar_metadata.bookkeeper.usePulsarMetadataBookieDriver) }}
+# there's a bug when using PulsarMetadataBookieDriver since it always appends /ledgers to the metadataServiceUri
+# Possibly a bug in org.apache.pulsar.metadata.bookkeeper.AbstractMetadataDriver#resolveLedgersRootPath in Pulsar code base
 metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-zkLedgersRootPath: "/ledgers"
 {{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -107,6 +107,11 @@ zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
 {{- else if .Values.components.oxia }}
 metadataServiceUri: "{{ template "pulsar.oxia.metadata.url.bookkeeper" . }}"
 {{- end }}
+{{- /* metadataStoreSessionTimeoutMillis maps to zkTimeout in bookkeeper.conf for both zookeeper and oxia metadata stores */}}
+{{- if (and (hasKey .Values.pulsar_metadata "bookkeeper") (hasKey .Values.pulsar_metadata.bookkeeper "metadataStoreSessionTimeoutMillis")) }}
+zkTimeout: "{{ .Values.pulsar_metadata.bookkeeper.metadataStoreSessionTimeoutMillis }}"
+{{- end }}
+
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -98,7 +98,7 @@ Define bookie common config
 */}}
 {{- define "pulsar.bookkeeper.config.common" -}}
 {{- if .Values.components.zookeeper }}
-{{- if .Values.usePulsarMetadataBookieDriver }}
+{{- if (and (hasKey .Values.pulsar_metadata "bookkeeper") .Values.pulsar_metadata.bookkeeper.usePulsarMetadataBookieDriver) }}
 metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
 {{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -119,7 +119,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.autorecovery.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-        - >
+        - |
           {{- include "pulsar.autorecovery.init.verify_cluster_id" . | nindent 10 }}
         envFrom:
         - configMapRef:
@@ -144,7 +144,7 @@ spec:
       {{- end}}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.autorecovery.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/bookkeeper autorecovery

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -52,7 +52,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             export PULSAR_MEM="-Xmx128M";
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -71,7 +71,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -86,7 +86,7 @@ spec:
       {{- end }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.initTimeout | default 60 }}", "sh", "-c"]
         args:
-          - >
+          - |
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
             export BOOKIE_MEM="-Xmx128M";

--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,19 +61,5 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
-  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
-  # Set RocksDB default format version to 5
-  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
-  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
-  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
-  {{- else }}
-  # Specify existing files to load RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
-  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,5 +61,19 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
+  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
+  # Set RocksDB default format version to 5
+  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
+  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
+  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
+  {{- else }}
+  # Specify existing files to load RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
+  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -177,9 +177,25 @@ spec:
         command: ["sh", "-c"]
         args:
         - |
-        {{- if .Values.bookkeeper.additionalCommand }}
+          # set required environment variables to use rocksdb config files provided in the Pulsar image
+          export PULSAR_PREFIX_defaultRocksdbConf=${PULSAR_PREFIX_defaultRocksdbConf:-conf/default_rocksdb.conf}
+          export PULSAR_PREFIX_entryLocationRocksdbConf=${PULSAR_PREFIX_entryLocationRocksdbConf:-conf/entry_location_rocksdb.conf}
+          export PULSAR_PREFIX_ledgerMetadataRocksdbConf=${PULSAR_PREFIX_ledgerMetadataRocksdbConf:-conf/ledger_metadata_rocksdb.conf}
+          if [ -x bin/update-rocksdb-conf-from-env.py ] && [ -f "${PULSAR_PREFIX_entryLocationRocksdbConf}" ]; then
+            echo "Updating ${PULSAR_PREFIX_entryLocationRocksdbConf} from environment variables starting with dbStorage_rocksDB_*"
+            bin/update-rocksdb-conf-from-env.py "${PULSAR_PREFIX_entryLocationRocksdbConf}"
+          else
+            # Ensure that Bookkeeper will not load RocksDB config from existing files and fallback to use default RocksDB config
+            # See https://github.com/apache/bookkeeper/pull/3523 as reference
+            export PULSAR_PREFIX_defaultRocksdbConf=conf/non_existing_default_rocksdb.conf
+            export PULSAR_PREFIX_entryLocationRocksdbConf=conf/non_existing_entry_location_rocksdb.conf
+            export PULSAR_PREFIX_ledgerMetadataRocksdbConf=conf/non_existing_ledger_metadata_rocksdb.conf
+            # Ensure that Bookkeeper will use RocksDB format_version 5 (this currently applies only to the entry location rocksdb due to a bug in Bookkeeper)
+            export PULSAR_PREFIX_dbStorage_rocksDB_format_version=${PULSAR_PREFIX_dbStorage_rocksDB_format_version:-5}
+          fi
+          {{- if .Values.bookkeeper.additionalCommand }}
           {{ .Values.bookkeeper.additionalCommand }}
-        {{- end }}
+          {{- end }}
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -121,7 +121,7 @@ spec:
         command: ["timeout", "{{ .Values.bookkeeper.waitMetadataTimeout }}", "sh", "-c"]
         args:
         # only reformat bookie if bookkeeper is running without persistence
-        - >
+        - |
           {{- include "pulsar.bookkeeper.init.verify_cluster_id" . | nindent 10 }}
         envFrom:
         - configMapRef:
@@ -176,7 +176,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.bookkeeper.additionalCommand }}
           {{ .Values.bookkeeper.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -29,13 +29,13 @@ metadata:
 data:
   # Metadata settings
   {{- if .Values.components.zookeeper }}
-  metadataStoreUrl: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  metadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- if .Values.pulsar_metadata.configurationStore }}
-  configurationMetadataStoreUrl: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  configurationMetadataStoreUrl: "zk:{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
   {{- else }}
-  configurationMetadataStoreUrl: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  configurationMetadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- end }}
-  bookkeeperMetadataServiceUri: "metadata-store:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+  bookkeeperMetadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
   {{- end }}
   {{- if .Values.components.oxia }}
   metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url.broker" . }}"

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -30,16 +30,18 @@ data:
   # Metadata settings
   {{- if .Values.components.zookeeper }}
   metadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- $configMetadataStoreUrl := "" }}
   {{- if .Values.pulsar_metadata.configurationStore }}
-  configurationMetadataStoreUrl: "zk:{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  {{- $configMetadataStoreUrl = printf "zk:%s%s" (include "pulsar.configurationStore.connect" .) .Values.pulsar_metadata.configurationStoreMetadataPrefix }}
   {{- else }}
-  configurationMetadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- $configMetadataStoreUrl = printf "zk:%s%s" (include "pulsar.zookeeper.connect" .) .Values.metadataPrefix }}
   {{- end }}
+  configurationMetadataStoreUrl: "{{ $configMetadataStoreUrl }}"
   # setting bookkeeperMetadataServiceUri causes a NPE in WorkerUtils.initializeDlogNamespace which is a bug in Pulsar
   # omit setting bookkeeperMetadataServiceUri until the bug is fixed when functions are enabled.
   # bookkeeperMetadataServiceUri will default to configurationMetadataStoreUrl + "/ledgers" in that case
   {{- if not .Values.components.functions }}
-  bookkeeperMetadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+  bookkeeperMetadataServiceUri: "metadata-store:{{ $configMetadataStoreUrl }}/ledgers"
   {{- end }}
   {{- end }}
   {{- if .Values.components.oxia }}

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -43,11 +43,35 @@ data:
   bookkeeperMetadataServiceUri: "{{ template "pulsar.oxia.metadata.url.bookkeeper" . }}"
   {{- end }}
 
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreAllowReadOnlyOperations" }}
+  PULSAR_PREFIX_metadataStoreAllowReadOnlyOperations: "{{ .Values.pulsar_metadata.metadataStoreAllowReadOnlyOperations }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreSessionTimeoutMillis" }}
+  metadataStoreSessionTimeoutMillis: "{{ .Values.pulsar_metadata.metadataStoreSessionTimeoutMillis }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreOperationTimeoutSeconds" }}
+  metadataStoreOperationTimeoutSeconds: "{{ .Values.pulsar_metadata.metadataStoreOperationTimeoutSeconds }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreCacheExpirySeconds" }}
+  metadataStoreCacheExpirySeconds: "{{ .Values.pulsar_metadata.metadataStoreCacheExpirySeconds }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingEnabled" }}
+  metadataStoreBatchingEnabled: "{{ .Values.pulsar_metadata.metadataStoreBatchingEnabled }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxDelayMillis" }}
+  metadataStoreBatchingMaxDelayMillis: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxDelayMillis }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxOperations" }}
+  metadataStoreBatchingMaxOperations: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxOperations }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxSizeKb" }}
+  metadataStoreBatchingMaxSizeKb: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxSizeKb }}"
+  {{- end }}
+
   # Broker settings
   clusterName: {{ template "pulsar.cluster.name" . }}
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
-  metadataStoreSessionTimeoutMillis: "30000"
   statusFilePath: "{{ template "pulsar.home" . }}/logs/status"
 
   # Tiered storage settings

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -29,13 +29,13 @@ metadata:
 data:
   # Metadata settings
   {{- if .Values.components.zookeeper }}
-  zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  metadataStoreUrl: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- if .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  configurationMetadataStoreUrl: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  {{- else }}
+  configurationMetadataStoreUrl: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- end }}
-  {{- if not .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-  {{- end }}
+  bookkeeperMetadataServiceUri: "metadata-store:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
   {{- end }}
   {{- if .Values.components.oxia }}
   metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url.broker" . }}"
@@ -47,7 +47,7 @@ data:
   clusterName: {{ template "pulsar.cluster.name" . }}
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
-  zooKeeperSessionTimeoutMillis: "30000"
+  metadataStoreSessionTimeoutMillis: "30000"
   statusFilePath: "{{ template "pulsar.home" . }}/logs/status"
 
   # Tiered storage settings

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -35,7 +35,12 @@ data:
   {{- else }}
   configurationMetadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   {{- end }}
+  # setting bookkeeperMetadataServiceUri causes a NPE in WorkerUtils.initializeDlogNamespace which is a bug in Pulsar
+  # omit setting bookkeeperMetadataServiceUri until the bug is fixed when functions are enabled.
+  # bookkeeperMetadataServiceUri will default to configurationMetadataStoreUrl + "/ledgers" in that case
+  {{- if not .Values.components.functions }}
   bookkeeperMetadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
+  {{- end }}
   {{- end }}
   {{- if .Values.components.oxia }}
   metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url.broker" . }}"

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             export PULSAR_MEM="-Xmx128M";
             {{- if .Values.pulsar_metadata.configurationStore }}
@@ -161,7 +161,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -175,7 +175,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-          - >
+          - |
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             export BOOKIE_MEM="-Xmx128M";
@@ -244,7 +244,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.broker.additionalCommand }}
           {{ .Values.broker.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -118,7 +118,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             export PULSAR_MEM="-Xmx128M";
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -137,7 +137,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -151,7 +151,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitBrokerTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             set -e;
             brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
             until [ ${brokerServiceNumber} -ge 1 ]; do
@@ -203,7 +203,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.proxy.additionalCommand }}
           {{ .Values.proxy.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -49,7 +49,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ .Values.pulsar_metadata.configurationStore}}; do
               sleep 3;
             done;
@@ -60,7 +60,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- if $zk := .Values.pulsar_metadata.userProvidedZookeepers }}
             export PULSAR_MEM="-Xmx128M";
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -79,7 +79,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -93,7 +93,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-        - >-
+        - |
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
           echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -64,7 +64,7 @@ spec:
           resources: {{ toYaml .Values.initContainer.resources | nindent 12 }}
           command: [ "sh", "-c" ]
           args:
-            - >-
+            - |
               set -e;
               brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
               until [ ${brokerServiceNumber} -ge 1 ]; do

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.toolset.additionalCommand }}
           {{ .Values.toolset.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.zookeeper.additionalCommand }}
           {{ .Values.zookeeper.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -54,13 +54,6 @@ useReleaseStatus: true
 ## be stored under the provided path
 metadataPrefix: ""
 
-## Controls whether to use the PIP-45 metadata driver (PulsarMetadataBookieDriver) for BookKeeper components
-## when using ZooKeeper as a metadata store.
-## This is a global setting that applies to all BookKeeper components.
-## When set to true, BookKeeper components will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
-## When set to false, BookKeeper components will use BookKeeper's default ZooKeeper connection implementation.
-usePulsarMetadataBookieDriver: true
-
 ## Port name prefix
 ##
 ## Used for Istio support which depends on a standard naming of ports
@@ -886,6 +879,44 @@ pulsar_metadata:
   waitBookkeeperTimeout: 120
   ## Timeout for running metadata initialization
   initTimeout: 60
+
+  ## Allow read-only operations on the metadata store when the metadata store is not available.
+  ## This is useful when you want to continue serving requests even if the metadata store is not fully available with quorum.
+  metadataStoreAllowReadOnlyOperations: false
+
+  ## The session timeout for the metadata store in milliseconds.
+  metadataStoreSessionTimeoutMillis: 30000
+
+  ## Metadata store operation timeout in seconds.
+  metadataStoreOperationTimeoutSeconds: 30
+
+  ## The expiry time for the metadata store cache in seconds.
+  metadataStoreCacheExpirySeconds: 300
+
+  ## Whether we should enable metadata operations batching
+  metadataStoreBatchingEnabled: true
+  
+  ## Maximum delay to impose on batching grouping (in milliseconds)
+  metadataStoreBatchingMaxDelayMillis: 5
+  
+  ## Maximum number of operations to include in a singular batch
+  metadataStoreBatchingMaxOperations: 1000
+  
+  ## Maximum size of a batch (in KB)
+  metadataStoreBatchingMaxSizeKb: 128
+
+  ## BookKeeper metadata configuration settings with Pulsar Helm Chart deployments
+  bookkeeper:
+    ## Controls whether to use the PIP-45 metadata driver (PulsarMetadataBookieDriver) for BookKeeper components
+    ## when using ZooKeeper as a metadata store.
+    ## This is a global setting that applies to all BookKeeper components.
+    ## When set to true, BookKeeper components will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
+    ## When set to false, BookKeeper components will use BookKeeper's default ZooKeeper connection implementation.
+    usePulsarMetadataBookieDriver: true
+
+    ## The session timeout for the metadata store in milliseconds. This setting is mapped to `zkTimeout` in `bookkeeper.conf`.
+    ## due to implementation details in the PulsarMetadataBookieDriver, it also applies when Oxia metadata store is enabled.
+    metadataStoreSessionTimeoutMillis: 30000
 
   # resources for bin/pulsar initialize-cluster-metadata
   resources:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,6 +728,10 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
+  ## Use RocksDB config in configData
+  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
+  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
+  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1378,9 +1378,15 @@ toolset:
 ## https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
 ## For sample values, please see their documentation.
 kube-prometheus-stack:
+  ## Enable the kube-prometheus-stack chart
   enabled: true
+  ## Manages Prometheus and Alertmanager components
+  prometheusOperator:
+    enabled: true
+  ## Prometheus component
   prometheus:
     enabled: true
+  ## Grafana component
   grafana:
     enabled: true
     # Use random password at installation time for Grafana by default by setting empty value to `adminPassword`.
@@ -1451,10 +1457,15 @@ kube-prometheus-stack:
         zookeeper:
           url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/zookeeper-3.6.json
           datasource: Prometheus
+        offloader:
+          url: https://raw.githubusercontent.com/apache/pulsar/refs/heads/master/grafana/dashboards/offloader.json
+          datasource: Prometheus
+  ## Prometheus node exporter component
   prometheus-node-exporter:
     enabled: true
     hostRootFsMount:
       enabled: false
+  ## Alertmanager component
   alertmanager:
     enabled: false
 

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,10 +728,6 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
-  ## Use RocksDB config in configData
-  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
-  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
-  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -54,6 +54,13 @@ useReleaseStatus: true
 ## be stored under the provided path
 metadataPrefix: ""
 
+## Controls whether to use the PIP-45 metadata driver (PulsarMetadataBookieDriver) for BookKeeper components
+## when using ZooKeeper as a metadata store.
+## This is a global setting that applies to all BookKeeper components.
+## When set to true, BookKeeper components will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
+## When set to false, BookKeeper components will use BookKeeper's default ZooKeeper connection implementation.
+usePulsarMetadataBookieDriver: true
+
 ## Port name prefix
 ##
 ## Used for Istio support which depends on a standard naming of ports

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -895,13 +895,13 @@ pulsar_metadata:
 
   ## Whether we should enable metadata operations batching
   metadataStoreBatchingEnabled: true
-  
+
   ## Maximum delay to impose on batching grouping (in milliseconds)
   metadataStoreBatchingMaxDelayMillis: 5
-  
+
   ## Maximum number of operations to include in a singular batch
   metadataStoreBatchingMaxOperations: 1000
-  
+
   ## Maximum size of a batch (in KB)
   metadataStoreBatchingMaxSizeKb: 128
 

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -25,7 +25,7 @@ set -e
 NAMESPACE=cert-manager
 NAME=cert-manager
 # check compatibility with k8s versions from https://cert-manager.io/docs/installation/supported-releases/
-VERSION=v1.12.13
+VERSION=v1.12.16
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."


### PR DESCRIPTION
- **Replace deprecated Zookeeper client config in broker and bookie components with PIP-45 config and make PulsarMetadataBookieDriver configurable**
- **Add "zk:" prefix**
- **Add support for PIP-45 metadata store configuration in values.yaml**
- **Workaround NPE when setting bookkeeperMetadataServiceUri when functions are enabled**
- **Make bookeeperMetadataServiceUri handle pulsar_metadata.configurationStore logic**
- **Use correct key**
- **Replace ">" with "|" to avoid Go Yaml issue go-yaml/yaml#789**
- **Remove leading whitespace from commands**
- **Upgrade k9s version used in ssh shell**
- **Test with single scenario**
