### PR TITLE
lh change proxy load balancer type

### DIFF
--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -62,6 +62,8 @@ if [[ "$UPGRADE_FROM_VERSION" != "" ]]; then
     install_type="upgrade"
     echo "Wait 10 seconds"
     sleep 10
+    # check pulsar environment
+    ci::check_pulsar_environment
     # test that we can access the admin api
     ci::test_pulsar_admin_api_access
     # produce messages with old version of pulsar and consume with new version

--- a/.ci/chart_test.sh
+++ b/.ci/chart_test.sh
@@ -28,6 +28,7 @@ TLS=${TLS:-"false"}
 SYMMETRIC=${SYMMETRIC:-"false"}
 FUNCTION=${FUNCTION:-"false"}
 MANAGER=${MANAGER:-"false"}
+ALLOW_LOADBALANCERS=${ALLOW_LOADBALANCERS:-"false"}
 
 source ${PULSAR_HOME}/.ci/helm.sh
 
@@ -56,6 +57,7 @@ fi
 install_type="install"
 test_action="produce-consume"
 if [[ "$UPGRADE_FROM_VERSION" != "" ]]; then
+    ALLOW_LOADBALANCERS="true"
     # install older version of pulsar chart
     PULSAR_CHART_VERSION="$UPGRADE_FROM_VERSION"
     ci::install_pulsar_chart install ${PULSAR_HOME}/.ci/values-common.yaml ${PULSAR_HOME}/${VALUES_FILE} "${extra_opts[@]}"
@@ -82,6 +84,11 @@ ci::install_pulsar_chart ${install_type} ${PULSAR_HOME}/.ci/values-common.yaml $
 
 echo "Wait 10 seconds"
 sleep 10
+
+# check that there aren't any loadbalancers if ALLOW_LOADBALANCERS is false
+if [[ "${ALLOW_LOADBALANCERS}" == "false" ]]; then
+    ci::check_loadbalancers
+fi
 
 # check pulsar environment
 ci::check_pulsar_environment

--- a/.ci/clusters/values-prometheus-grafana.yaml
+++ b/.ci/clusters/values-prometheus-grafana.yaml
@@ -19,6 +19,8 @@
 
 kube-prometheus-stack:
   enabled: true
+  prometheusOperator:
+    enabled: true
   prometheus:
     enabled: true
   grafana:

--- a/.ci/configure_ci_runner_for_debugging.sh
+++ b/.ci/configure_ci_runner_for_debugging.sh
@@ -27,7 +27,7 @@ function k9s() {
     # install k9s on the fly
     if [ ! -x /usr/local/bin/k9s ]; then
         echo "Installing k9s..."
-        curl -L -s https://github.com/derailed/k9s/releases/download/v0.32.5/k9s_Linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin k9s
+        curl -L -s https://github.com/derailed/k9s/releases/download/v0.40.5/k9s_Linux_amd64.tar.gz | sudo tar xz -C /usr/local/bin k9s
     fi
     command k9s "$@"
 }

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -424,6 +424,18 @@ function ci::test_pulsar_manager() {
   fi
 }
 
+function ci::check_loadbalancers() {
+  (
+  set +e
+  ${KUBECTL} get services -n ${NAMESPACE} | grep LoadBalancer
+  if [ $? -eq 0 ]; then
+    echo "Error: Found service with type LoadBalancer. This is not allowed because of security reasons."
+    exit 1
+  fi
+  exit 0
+  )
+}
+
 function ci::validate_kustomize_yaml() {
   # if kustomize is not installed, install kustomize to a temp directory
   if ! command -v kustomize &> /dev/null; then

--- a/.ci/values-common.yaml
+++ b/.ci/values-common.yaml
@@ -55,6 +55,12 @@ bookkeeper:
     diskUsageWarnThreshold: "0.999"
     PULSAR_PREFIX_diskUsageThreshold: "0.999"
     PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
+    # minimal memory use for bookkeeper
+    # https://bookkeeper.apache.org/docs/reference/config#db-ledger-storage-settings
+    dbStorage_writeCacheMaxSizeMb: "32"
+    dbStorage_readAheadCacheMaxSizeMb: "32"
+    dbStorage_rocksDB_writeBufferSizeMB: "8"
+    dbStorage_rocksDB_blockCacheSize: "8388608"    
 
 broker:
   replicaCount: 1

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,3 @@ charts/**/*.lock
 PRIVATEKEY
 PUBLICKEY
 .vagrant/
-pulsarctl-*-*.tar.gz
-pulsarctl-*-*/

--- a/README.md
+++ b/README.md
@@ -27,26 +27,106 @@ Read [Deploying Pulsar on Kubernetes](http://pulsar.apache.org/docs/deploy-kuber
 
 > :warning: This helm chart is updated outside of the regular Pulsar release cycle and might lag behind a bit. It only supports basic Kubernetes features now. Currently, it can be used as no more than a template and starting point for a Kubernetes deployment. In many cases, it would require some customizations.
 
-## Important Security Disclaimer for Helm Chart Usage
+## Important Security Advisory for Helm Chart Usage
 
 ### Notice of Default Configuration
-This Helm chart is provided with a default configuration that does not meet the security requirements for production environments or sensitive data handling. Users are strongly advised to thoroughly review and customize the security settings to ensure a secure deployment that aligns with their specific operational and security policies.
+
+This Helm chart's default configuration DOES NOT meet production security requirements.
+Users MUST review and customize security settings for their specific environment.
+
+IMPORTANT: This Helm chart provides a starting point for Pulsar deployments but requires
+significant security customization before use in production environments. We strongly
+recommend implementing:
+
+1. Authentication and authorization for all components
+2. TLS encryption for all communication channels
+3. Proper network isolation and access controls
+4. Regular security updates and vulnerability assessments
+
+As an open source project, we welcome contributions to improve security features.
+Please consider submitting pull requests to address security gaps or enhance
+existing security implementations.
 
 ### Pulsar Proxy Security Considerations
+
 As per the [Pulsar Proxy documentation](https://pulsar.apache.org/docs/3.1.x/administration-proxy/), it is explicitly stated that the Pulsar proxy is not designed for exposure to the public internet. The design assumes that deployments will be protected by network perimeter security measures. It is crucial to understand that relying solely on the default configuration can expose your deployment to significant security vulnerabilities.
 
-#### Recommendations:
+### Important Change in 4.0.0 version of the Apache Pulsar Helm chart
+
+The default service type for the Pulsar proxy has changed from `LoadBalancer` to `ClusterIP` for security reasons. This limits access to within the Kubernetes environment by default.
+
+### External Access Recommendations
+
+If you need to expose the Pulsar Proxy outside the cluster:
+
+1. **USE INTERNAL LOAD BALANCERS ONLY**
+   - Set type to LoadBalancer only in secured environments with proper network controls
+   - Add cloud provider-specific annotations for internal load balancers:
+     - Kubernetes documentation about internal load balancers:
+        - [Internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
+     - See cloud provider documentation:
+       - AWS / EKS: [AWS Load Balancer Controller / Service Annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/)
+       - Azure / AKS: [Use an internal load balancer with Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/internal-lb)
+       - GCP / GKE: [LoadBalancer service parameters](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters)
+     - Examples (verify correctness for your environment):
+       - AWS / EKS:  `service.beta.kubernetes.io/aws-load-balancer-internal: "true"`
+       - Azure / AKS: `service.beta.kubernetes.io/azure-load-balancer-internal: "true"`
+       - GCP / GKE:   `networking.gke.io/load-balancer-type: "Internal"`
+
+2. **IMPLEMENT AUTHENTICATION AND AUTHORIZATION**
+   - Configure all clients to authenticate properly
+   - Set up appropriate authorization policies
+
+3. **USE TLS FOR ALL CONNECTIONS**
+   - Enable TLS for client-to-proxy connections
+   - Enable TLS for proxy-to-broker connections
+   - Enable TLS for all internal cluster communications
+   - Note: TLS alone is NOT sufficient as a security solution. Even with TLS enabled, clusters exposed to untrusted networks remain vulnerable to denial-of-service attacks, authentication bypass attempts, and protocol-level exploits.
+
+4. **NETWORK SECURITY**
+   - Use private networks (VPCs)
+   - Configure firewalls, security groups, and IP restrictions
+
+5. **CLIENT IP ADDRESS BASED ACCESS RESTRICTIONS**
+
+   - When using a LoadBalancer service type, restrict access to specific IP ranges by configuring `proxy.service.loadBalancerSourceRanges` in your values.yaml:
+     ```yaml
+     proxy:
+       service:
+         loadBalancerSourceRanges:
+           - 10.0.0.0/8     # Private network range
+           - 172.16.0.0/12  # Private network range
+           - 192.168.0.0/16 # Private network range
+     ```
+   - This feature:
+     - Provides an additional defense layer by filtering traffic at the load balancer level
+     - Only allows connections from specified CIDR blocks
+     - Works only with LoadBalancer service type and when your cloud provider supports the `loadBalancerSourceRanges` parameter
+   - Important: This should be implemented alongside other security measures (internal load balancer, authentication, TLS, network policies) as part of a defense-in-depth strategy,
+     not as a standalone security solution
+
+### Alternative for External Access
+
+As an alternative method for external access, Pulsar has support for [SNI proxy routing](https://pulsar.apache.org/docs/next/concepts-proxy-sni-routing/). SNI Proxy routing is supported with proxy servers such as Apache Traffic Server, HAProxy and Nginx.
+
+Note: This option isn't currently implemented in the Apache Pulsar Helm chart.
+
+**IMPORTANT**: Pulsar binary protocol cannot be exposed outside of the Kubernetes cluster using Kubernetes Ingress. Kubernetes Ingress works for the Admin REST API and topic lookups, but clients would be connecting to the advertised listener addresses returned by the brokers and it would only work when clients can connect directly to brokers. This is not a supported secure option for exposing Pulsar to untrusted networks.
+
+### General Recommendations
+
 - **Network Perimeter Security:** It is imperative to implement robust network perimeter security to safeguard your deployment. The absence of such security measures can lead to unauthorized access and potential data breaches.
 - **Restricted Access:** For environments where security is less critical, such as certain development or testing scenarios, the use of `loadBalancerSourceRanges` may be employed to restrict access to specified IP addresses or ranges. This, however, should not be considered a substitute for comprehensive security measures in production environments.
 
 ### User Responsibility
+
 The user assumes full responsibility for the security and integrity of their deployment. This includes, but is not limited to, the proper configuration of security features and adherence to best practices for securing network access. The providers of this Helm chart disclaim all warranties, whether express or implied, including any warranties of merchantability, fitness for a particular purpose, and non-infringement of third-party rights.
 
 ### No Security Guarantees
+
 The providers of this Helm chart make no guarantees regarding the security of the chart under any circumstances. It is the user's responsibility to ensure that their deployment is secure and complies with all relevant security standards and regulations.
 
 By using this Helm chart, the user acknowledges the risks associated with its default configuration and the necessity for proper security customization. The user further agrees that the providers of the Helm chart shall not be liable for any security breaches or incidents resulting from the use of the chart.
-
 
 ## Features
 
@@ -114,7 +194,8 @@ Before proceeding to deploying Pulsar, you need to prepare your environment.
 To add this chart to your local Helm repository:
 
 ```bash
-helm repo add apache https://pulsar.apache.org/charts
+helm repo add apachepulsar https://pulsar.apache.org/charts
+helm repo update
 ```
 
 ## Kubernetes cluster preparation
@@ -126,14 +207,49 @@ We provide some instructions to guide you through the preparation: http://pulsar
 ## Deploy Pulsar to Kubernetes
 
 1. Configure your values file. The best way to know which values are available is to read the [values.yaml](./charts/pulsar/values.yaml).
+   A best practice is to start with an empty values file and only set the keys that differ from the default configuration.
+
+   Anti-affinity rules for Zookeeper and Bookie components require at least one node per replica. For Kubernetes clusters with less than 3 nodes,
+   you must disable this feature by adding this to your initial values.yaml file:
+
+    ```yaml
+    affinity:
+      anti_affinity: false
+    ```
 
 2. Install the chart:
 
     ```bash
-    helm install <release-name> -n <namespace> -f your-values.yaml apache/pulsar
+    helm install -n <namespace> --create-namespace <release-name> -f your-values.yaml apachepulsar/pulsar
     ```
 
-3. Access the Pulsar cluster
+3. Observe the deployment progress
+
+    Watching events to view progress of deployment:
+
+    ```shell
+    kubectl get -n <namespace> events -o wide --watch
+    ```
+
+    Watching state of deployed Kubernetes objects, updated every 2 seconds:
+
+    ```shell
+    watch kubectl get -n <namespace> all
+    ```
+
+    Waiting until Pulsar Proxy is available:
+
+    ```shell
+    kubectl wait --timeout=600s --for=condition=ready pod -n <namespace> -l component=proxy
+    ```
+
+    Watching state with k9s (https://k9scli.io/topics/install/):
+
+    ```shell
+    k9s -n <namespace>
+    ```
+
+4. Access the Pulsar cluster
 
     The default values will create a `ClusterIP` for the proxy you can use to interact with the cluster. To find the IP address of proxy use:
 
@@ -144,7 +260,7 @@ We provide some instructions to guide you through the preparation: http://pulsar
 For more information, please follow our detailed
 [quick start guide](https://pulsar.apache.org/docs/getting-started-helm/).
 
-## Customize the deployment 
+## Customize the deployment
 
 We provide a [detailed guideline](https://pulsar.apache.org/docs/helm-deploy/) for you to customize
 the Helm Chart for a production-ready deployment.
@@ -236,11 +352,12 @@ Once your Pulsar Chart is installed, configuration changes and chart
 updates should be done using `helm upgrade`.
 
 ```bash
-helm repo add apache https://pulsar.apache.org/charts
+helm repo add apachepulsar https://pulsar.apache.org/charts
 helm repo update
-helm get values <pulsar-release-name> > pulsar.yaml
-helm upgrade -f pulsar.yaml \
-    <pulsar-release-name> apache/pulsar
+# get the existing values.yaml used for the most recent deployment
+helm get values -n <namespace> <pulsar-release-name> > values.yaml
+# upgrade the deployment
+helm upgrade -n <namespace> -f values.yaml <pulsar-release-name> apachepulsar/pulsar
 ```
 
 For more detailed information, see our [Upgrading](http://pulsar.apache.org/docs/helm-upgrade/) guide.
@@ -249,7 +366,7 @@ For more detailed information, see our [Upgrading](http://pulsar.apache.org/docs
 
 The kube-prometheus-stack version has been upgraded to 69.x.x in Pulsar Helm Chart version 4.0.0 .
 Before running "helm upgrade", you should first upgrade the Prometheus Operator CRDs as [instructed
-in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-68x-to-69x). 
+in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-68x-to-69x).
 
 There's a script to run the required commands:
 
@@ -263,7 +380,7 @@ After, this you can proceed with `helm upgrade`.
 
 The kube-prometheus-stack version has been upgraded to 65.x.x in Pulsar Helm Chart version 3.7.0 .
 Before running "helm upgrade", you should first upgrade the Prometheus Operator CRDs as [instructed
-in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-64x-to-65x). 
+in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-64x-to-65x).
 
 There's a script to run the required commands:
 
@@ -277,7 +394,7 @@ After, this you can proceed with `helm upgrade`.
 
 The kube-prometheus-stack version has been upgraded to 59.x.x in Pulsar Helm Chart version 3.5.0 .
 Before running "helm upgrade", you should first upgrade the Prometheus Operator CRDs as [instructed
-in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-58x-to-59x). 
+in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-58x-to-59x).
 
 There's a script to run the required commands:
 
@@ -291,7 +408,7 @@ After, this you can proceed with `helm upgrade`.
 
 The kube-prometheus-stack version has been upgraded to 56.x.x in Pulsar Helm Chart version 3.3.0 .
 Before running "helm upgrade", you should first upgrade the Prometheus Operator CRDs as [instructed
-in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-55x-to-56x). 
+in kube-prometheus-stack upgrade notes](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack#from-55x-to-56x).
 
 There's a script to run the required commands:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -243,10 +243,10 @@ Public keys are available at: https://www.apache.org/dist/pulsar/KEYS
 
 For convenience "index.yaml" has been uploaded (though excluded from voting), so you can also run the below commands.
 
-helm repo add --force-update \
+helm repo add --force-update \\
  apache-pulsar-dist-dev https://dist.apache.org/repos/dist/dev/pulsar/helm-chart/$VERSION_RC/
 helm repo update
-helm install pulsar apache-pulsar-dist-dev/pulsar \
+helm install pulsar apache-pulsar-dist-dev/pulsar \\
  --version ${VERSION_WITHOUT_RC} --set affinity.anti_affinity=false
 
 pulsar-${VERSION_WITHOUT_RC}.tgz.prov - is also uploaded for verifying Chart Integrity, though it is not strictly required for releasing the artifact based on ASF Guidelines. 

--- a/charts/pulsar/templates/NOTES.txt
+++ b/charts/pulsar/templates/NOTES.txt
@@ -1,18 +1,185 @@
+======================================================================================
+                           APACHE PULSAR HELM CHART
+======================================================================================
+
+======================================================================================
+                           SECURITY ADVISORY
+======================================================================================
+
+This Helm chart's default configuration DOES NOT meet production security requirements.
+Users MUST review and customize security settings for their specific environment.
+
+IMPORTANT: This Helm chart provides a starting point for Pulsar deployments but requires
+significant security customization before use in production environments. We strongly
+recommend implementing:
+
+1. Proper network isolation and access controls
+2. Authentication and authorization for all components
+3. TLS encryption for all communication channels
+4. Regular security updates and vulnerability assessments
+
+As an open source project, we welcome contributions to improve security features.
+Please consider submitting pull requests to address security gaps or enhance
+existing security implementations.
+
+---------------------------------------------------------------------------------------
+
+SECURITY NOTICE: The Pulsar proxy is not designed for direct public internet exposure.
+It lacks security features required for untrusted networks and should only be deployed
+within secured environments with proper network controls.
+
+IMPORTANT CHANGE IN v4.0.0: Default service type changed from LoadBalancer to ClusterIP
+for security reasons. This limits access to within the Kubernetes environment by default.
+
+---------------------------------------------------------------------------------------
+IF YOU NEED EXTERNAL ACCESS FOR YOUR PULSAR CLUSTER:
+---------------------------------------------------------------------------------------
+
+Note: This information might be outdated. Please go to https://github.com/apache/pulsar-helm-chart for updated information.
+
+If you need to expose the Pulsar Proxy outside the cluster using a LoadBalancer service type:
+
+1. USE INTERNAL LOAD BALANCERS ONLY
+   - Set type to LoadBalancer only in secured environments with proper network controls
+   - Add cloud provider-specific annotations for internal load balancers
+   - See cloud provider documentation:
+     * AWS / EKS: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/
+     * Azure / AKS: https://learn.microsoft.com/en-us/azure/aks/internal-lb
+     * GCP / GKE: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters
+   - Examples (verify correctness for your environment):
+     * AWS / EKS:  service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+     * Azure / AKS: service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+     * GCP / GKE:   networking.gke.io/load-balancer-type: "Internal"
+
+2. IMPLEMENT AUTHENTICATION AND AUTHORIZATION
+   - Configure all clients to authenticate properly
+   - Set up appropriate authorization policies
+
+3. USE TLS FOR ALL CONNECTIONS
+   - Enable TLS for client-to-proxy connections
+   - Enable TLS for proxy-to-broker connections
+   - Enable TLS for all internal cluster communications (brokers, zookeepers, bookies)
+   - Note: TLS alone is NOT sufficient as a security solution in Pulsar. Even with TLS enabled,
+     clusters exposed to untrusted networks remain vulnerable to denial-of-service attacks, 
+     authentication bypass attempts, and protocol-level exploits. Always implement defense-in-depth
+     security measures and limit exposure to trusted networks only.
+
+4. NETWORK SECURITY
+   - Use private networks (VPCs)
+   - Configure firewalls, security groups, and IP restrictions appropriately
+   - In addition, consider using loadBalancerSourceRanges to limit access to specific IP ranges
+
+5. CLIENT IP ADDRESS BASED ACCESS RESTRICTIONS
+   - When using a LoadBalancer service type, restrict access to specific IP ranges by configuring 
+     `proxy.service.loadBalancerSourceRanges` in your values.yaml
+   - Important: This should be implemented alongside other security measures (internal load balancer,
+     authentication, TLS, network policies) as part of a defense-in-depth strategy,
+     not as a standalone security solution
+
+---------------------------------------------------------------------------------------
+ALTERNATIVE FOR EXTERNAL ACCESS
+---------------------------------------------------------------------------------------
+
+As an alternative method for external access, Pulsar has support for SNI proxy routing:
+https://pulsar.apache.org/docs/next/concepts-proxy-sni-routing/
+SNI Proxy routing is supported with proxy servers such as Apache Traffic Server, HAProxy and Nginx.
+
+Note: This option isn't currently implemented in the Apache Pulsar Helm chart.
+
+IMPORTANT: Pulsar binary protocol cannot be exposed outside of the Kubernetes cluster
+using Kubernetes Ingress. Kubernetes Ingress works for the Admin REST API and topic lookups,
+but clients would be connecting to the advertised listener addresses returned by the brokers and it 
+would only work when clients can connect directly to brokers. This is not a supported secure option 
+for exposing Pulsar to untrusted networks.
+
+{{- if .Values.useReleaseStatus }}
+
+======================================================================================
+                           🚀 QUICK START 🚀
+======================================================================================
+
+Watching events to view progress of deployment:
+kubectl get -n {{ .Values.namespace | default .Release.Namespace }} events -o wide --watch
+
+Watching state of deployed Kubernetes objects, updated every 2 seconds:
+watch kubectl get -n  {{ .Values.namespace | default .Release.Namespace }} all
+
+{{- if .Values.components.proxy }}
+
+Waiting until Pulsar Proxy is available:
+kubectl wait --timeout=600s --for=condition=ready pod -n {{ .Values.namespace | default .Release.Namespace }} -l component=proxy
+{{- end }}
+
+Watching state with k9s (https://k9scli.io/topics/install/):
+k9s -n {{ .Values.namespace | default .Release.Namespace }}
+
+{{- if and .Values.affinity.anti_affinity (or (gt (int .Values.bookkeeper.replicaCount) 1) (gt (int .Values.zookeeper.replicaCount) 1)) }}
+
+======================================================================================
+                      ⚠️  NOTICE FOR DEV K8S CLUSTER USERS  ⚠️
+======================================================================================
+
+Please note that anti-affinity rules for Zookeeper and Bookie components require at least 
+one node per replica. There are currently {{ .Values.bookkeeper.replicaCount }} bookies and {{ .Values.zookeeper.replicaCount }} zookeepers configured.
+
+For Kubernetes clusters with fewer than 3 nodes, such as single-node Kubernetes clusters in 
+development environments like minikube, Docker Desktop, Rancher Desktop (k3s), or Podman 
+Desktop, you must disable the anti-affinity feature by either:
+
+Adding to your values.yaml:
+affinity:
+  anti_affinity: false
+
+Or adding "--set affinity.anti_affinity=false" to the helm command line.
+
+After making the changes to your values yaml file, redeploy with "helm upgrade":
+helm upgrade -n {{ .Release.Namespace }} -f your_values_file.yaml {{ .Release.Name }} apachepulsar/pulsar
+
+These configuration instructions can be omitted for Kubernetes clusters with 3 or more nodes.
+{{- end }}
+{{- end }}
+{{- if and (eq .Values.proxy.service.type "LoadBalancer") (not .Values.proxy.service.annotations) }}
+
+======================================================================================
+                      ⚠️ 🚨 INSECURE CONFIGURATION DETECTED 🚨 ⚠️
+======================================================================================
+WARNING: You are using a LoadBalancer service type without internal load balancer
+annotations. This is potentially an insecure configuration. Please carefully review
+the security recommendations above and visit https://github.com/apache/pulsar-helm-chart
+for more information.
+======================================================================================
+{{- end }}
+
+======================================================================================
+                           DISCLAIMER
+======================================================================================
+
+The providers of this Helm chart make no guarantees regarding the security of the chart under
+any circumstances. It is the user's responsibility to ensure that their deployment is secure
+and complies with all relevant security standards and regulations.
+
+By using this Helm chart, the user acknowledges the risks associated with its default
+configuration and the necessity for proper security customization. The user further 
+agrees that the providers of the Helm chart shall not be liable for any security breaches
+or incidents resulting from the use of the chart.
+
+The user assumes full responsibility for the security and integrity of their deployment.
+This includes, but is not limited to, the proper configuration of security features and 
+adherence to best practices for securing network access. The providers of this Helm chart
+disclaim all warranties, whether express or implied, including any warranties of
+merchantability, fitness for a particular purpose, and non-infringement of third-party rights.
+
+======================================================================================
+                           RESOURCES
+======================================================================================
+
+- 🖥️ Install k9s terminal interface for viewing and managing k8s clusters: https://k9scli.io/topics/install/
+- ❓ Usage Questions: https://github.com/apache/pulsar/discussions/categories/q-a
+- 🐛 Report Issues: https://github.com/apache/pulsar-helm-chart/issues
+- 🔒 Security Issues: https://pulsar.apache.org/security/
+- 📚 Documentation: https://github.com/apache/pulsar-helm-chart
+
+🌟 Please contribute to improve the Apache Pulsar Helm chart and its documentation:
+- 🤝 Contribute: https://github.com/apache/pulsar-helm-chart
+
 Thank you for installing Apache Pulsar Helm chart version {{ .Chart.Version }}.
-
-!! WARNING !!
-
-Important Security Disclaimer for Apache Pulsar Helm Chart Usage:
-
-This Helm chart is provided with a default configuration that does not
-meet the security requirements for production environments or sensitive
-data handling. Users are strongly advised to thoroughly review and
-customize the security settings to ensure a secure deployment that
-aligns with their specific operational and security policies.
-
-Go to https://github.com/apache/pulsar-helm-chart for more details.
-
-Ask usage questions at https://github.com/apache/pulsar/discussions/categories/q-a
-Report issues to https://github.com/apache/pulsar-helm-chart/issues
-Please contribute improvements to https://github.com/apache/pulsar-helm-chart
-

--- a/charts/pulsar/templates/_bookkeeper.tpl
+++ b/charts/pulsar/templates/_bookkeeper.tpl
@@ -97,14 +97,22 @@ Define bookie tls certs volumes
 Define bookie common config
 */}}
 {{- define "pulsar.bookkeeper.config.common" -}}
+{{/*
+Configure BookKeeper's metadata store (available since BookKeeper 4.7.0 / BP-29)
+https://bookkeeper.apache.org/bps/BP-29-metadata-store-api-module/
+https://bookkeeper.apache.org/docs/deployment/manual#cluster-metadata-setup
+*/}}
+# Set empty values for zkServers and zkLedgersRootPath since we're using the metadataServiceUri to configure BookKeeper's metadata store
+zkServers: ""
+zkLedgersRootPath: ""
 {{- if .Values.components.zookeeper }}
 {{- if (and (hasKey .Values.pulsar_metadata "bookkeeper") .Values.pulsar_metadata.bookkeeper.usePulsarMetadataBookieDriver) }}
 # there's a bug when using PulsarMetadataBookieDriver since it always appends /ledgers to the metadataServiceUri
 # Possibly a bug in org.apache.pulsar.metadata.bookkeeper.AbstractMetadataDriver#resolveLedgersRootPath in Pulsar code base
 metadataServiceUri: "metadata-store:zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
 {{- else }}
-zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
-zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+# use zk+hierarchical:// when using BookKeeper's built-in metadata driver
+metadataServiceUri: "zk+hierarchical://{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}/ledgers"
 {{- end }}
 {{- else if .Values.components.oxia }}
 metadataServiceUri: "{{ template "pulsar.oxia.metadata.url.bookkeeper" . }}"

--- a/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -119,7 +119,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.autorecovery.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-        - >
+        - |
           {{- include "pulsar.autorecovery.init.verify_cluster_id" . | nindent 10 }}
         envFrom:
         - configMapRef:
@@ -144,7 +144,7 @@ spec:
       {{- end}}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.autorecovery.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/bookkeeper autorecovery

--- a/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper-cluster-initialize.yaml
@@ -52,7 +52,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             export PULSAR_MEM="-Xmx128M";
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -71,7 +71,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -86,7 +86,7 @@ spec:
       {{- end }}
         command: ["timeout", "{{ .Values.bookkeeper.metadata.initTimeout | default 60 }}", "sh", "-c"]
         args:
-          - >
+          - |
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
             export BOOKIE_MEM="-Xmx128M";

--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,19 +61,5 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
-  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
-  # Set RocksDB default format version to 5
-  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
-  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
-  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
-  {{- else }}
-  # Specify existing files to load RocksDB config from existing files
-  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
-  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
-  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
-  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper-configmap.yaml
@@ -61,5 +61,19 @@ data:
   {{- end }}
   # TLS config
   {{- include "pulsar.bookkeeper.config.tls" . | nindent 2 }}
+  {{- if .Values.bookkeeper.useRocksDBConfigInConfigData }}
+  # Set RocksDB default format version to 5
+  # RocksDB format_version 5 has been supported since RocksDB 6.6 . It's required for certain performance optimizations.
+  PULSAR_PREFIX_dbStorage_rocksDB_format_version: "5"
+  # Specify non-existing files to avoid Bookkeeper from loading RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/non_existing_default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/non_existing_entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/non_existing_ledger_metadata_rocksdb.conf"
+  {{- else }}
+  # Specify existing files to load RocksDB config from existing files
+  PULSAR_PREFIX_defaultRocksdbConf: "conf/default_rocksdb.conf"
+  PULSAR_PREFIX_entryLocationRocksdbConf: "conf/entry_location_rocksdb.conf"
+  PULSAR_PREFIX_ledgerMetadataRocksdbConf: "conf/ledger_metadata_rocksdb.conf"
+  {{- end }}
 {{ toYaml .Values.bookkeeper.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -177,9 +177,25 @@ spec:
         command: ["sh", "-c"]
         args:
         - |
-        {{- if .Values.bookkeeper.additionalCommand }}
+          # set required environment variables to use rocksdb config files provided in the Pulsar image
+          export PULSAR_PREFIX_defaultRocksdbConf=${PULSAR_PREFIX_defaultRocksdbConf:-conf/default_rocksdb.conf}
+          export PULSAR_PREFIX_entryLocationRocksdbConf=${PULSAR_PREFIX_entryLocationRocksdbConf:-conf/entry_location_rocksdb.conf}
+          export PULSAR_PREFIX_ledgerMetadataRocksdbConf=${PULSAR_PREFIX_ledgerMetadataRocksdbConf:-conf/ledger_metadata_rocksdb.conf}
+          if [ -x bin/update-rocksdb-conf-from-env.py ] && [ -f "${PULSAR_PREFIX_entryLocationRocksdbConf}" ]; then
+            echo "Updating ${PULSAR_PREFIX_entryLocationRocksdbConf} from environment variables starting with dbStorage_rocksDB_*"
+            bin/update-rocksdb-conf-from-env.py "${PULSAR_PREFIX_entryLocationRocksdbConf}"
+          else
+            # Ensure that Bookkeeper will not load RocksDB config from existing files and fallback to use default RocksDB config
+            # See https://github.com/apache/bookkeeper/pull/3523 as reference
+            export PULSAR_PREFIX_defaultRocksdbConf=conf/non_existing_default_rocksdb.conf
+            export PULSAR_PREFIX_entryLocationRocksdbConf=conf/non_existing_entry_location_rocksdb.conf
+            export PULSAR_PREFIX_ledgerMetadataRocksdbConf=conf/non_existing_ledger_metadata_rocksdb.conf
+            # Ensure that Bookkeeper will use RocksDB format_version 5 (this currently applies only to the entry location rocksdb due to a bug in Bookkeeper)
+            export PULSAR_PREFIX_dbStorage_rocksDB_format_version=${PULSAR_PREFIX_dbStorage_rocksDB_format_version:-5}
+          fi
+          {{- if .Values.bookkeeper.additionalCommand }}
           {{ .Values.bookkeeper.additionalCommand }}
-        {{- end }}
+          {{- end }}
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie;

--- a/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -121,7 +121,7 @@ spec:
         command: ["timeout", "{{ .Values.bookkeeper.waitMetadataTimeout }}", "sh", "-c"]
         args:
         # only reformat bookie if bookkeeper is running without persistence
-        - >
+        - |
           {{- include "pulsar.bookkeeper.init.verify_cluster_id" . | nindent 10 }}
         envFrom:
         - configMapRef:
@@ -176,7 +176,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.bookkeeper.additionalCommand }}
           {{ .Values.bookkeeper.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker-configmap.yaml
@@ -29,12 +29,19 @@ metadata:
 data:
   # Metadata settings
   {{- if .Values.components.zookeeper }}
-  zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  metadataStoreUrl: "zk:{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  {{- $configMetadataStoreUrl := "" }}
   {{- if .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
+  {{- $configMetadataStoreUrl = printf "zk:%s%s" (include "pulsar.configurationStore.connect" .) .Values.pulsar_metadata.configurationStoreMetadataPrefix }}
+  {{- else }}
+  {{- $configMetadataStoreUrl = printf "zk:%s%s" (include "pulsar.zookeeper.connect" .) .Values.metadataPrefix }}
   {{- end }}
-  {{- if not .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
+  configurationMetadataStoreUrl: "{{ $configMetadataStoreUrl }}"
+  # setting bookkeeperMetadataServiceUri causes a NPE in WorkerUtils.initializeDlogNamespace which is a bug in Pulsar
+  # omit setting bookkeeperMetadataServiceUri until the bug is fixed when functions are enabled.
+  # bookkeeperMetadataServiceUri will default to configurationMetadataStoreUrl + "/ledgers" in that case
+  {{- if not .Values.components.functions }}
+  bookkeeperMetadataServiceUri: "metadata-store:{{ $configMetadataStoreUrl }}/ledgers"
   {{- end }}
   {{- end }}
   {{- if .Values.components.oxia }}
@@ -43,11 +50,35 @@ data:
   bookkeeperMetadataServiceUri: "{{ template "pulsar.oxia.metadata.url.bookkeeper" . }}"
   {{- end }}
 
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreAllowReadOnlyOperations" }}
+  PULSAR_PREFIX_metadataStoreAllowReadOnlyOperations: "{{ .Values.pulsar_metadata.metadataStoreAllowReadOnlyOperations }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreSessionTimeoutMillis" }}
+  metadataStoreSessionTimeoutMillis: "{{ .Values.pulsar_metadata.metadataStoreSessionTimeoutMillis }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreOperationTimeoutSeconds" }}
+  metadataStoreOperationTimeoutSeconds: "{{ .Values.pulsar_metadata.metadataStoreOperationTimeoutSeconds }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreCacheExpirySeconds" }}
+  metadataStoreCacheExpirySeconds: "{{ .Values.pulsar_metadata.metadataStoreCacheExpirySeconds }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingEnabled" }}
+  metadataStoreBatchingEnabled: "{{ .Values.pulsar_metadata.metadataStoreBatchingEnabled }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxDelayMillis" }}
+  metadataStoreBatchingMaxDelayMillis: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxDelayMillis }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxOperations" }}
+  metadataStoreBatchingMaxOperations: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxOperations }}"
+  {{- end }}
+  {{- if hasKey .Values.pulsar_metadata "metadataStoreBatchingMaxSizeKb" }}
+  metadataStoreBatchingMaxSizeKb: "{{ .Values.pulsar_metadata.metadataStoreBatchingMaxSizeKb }}"
+  {{- end }}
+
   # Broker settings
   clusterName: {{ template "pulsar.cluster.name" . }}
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
-  zooKeeperSessionTimeoutMillis: "30000"
   statusFilePath: "{{ template "pulsar.home" . }}/logs/status"
 
   # Tiered storage settings

--- a/charts/pulsar/templates/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             export PULSAR_MEM="-Xmx128M";
             {{- if .Values.pulsar_metadata.configurationStore }}
@@ -161,7 +161,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -175,7 +175,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.broker.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-          - >
+          - |
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             bin/apply-config-from-env.py conf/bookkeeper.conf;
             export BOOKIE_MEM="-Xmx128M";
@@ -244,7 +244,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.broker.additionalCommand }}
           {{ .Values.broker.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy-statefulset.yaml
@@ -118,7 +118,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             export PULSAR_MEM="-Xmx128M";
             {{- if $zk:=.Values.pulsar_metadata.userProvidedZookeepers }}
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -137,7 +137,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -151,7 +151,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.proxy.waitBrokerTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             set -e;
             brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
             until [ ${brokerServiceNumber} -ge 1 ]; do
@@ -203,7 +203,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.proxy.additionalCommand }}
           {{ .Values.proxy.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -49,7 +49,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ .Values.pulsar_metadata.configurationStore}}; do
               sleep 3;
             done;
@@ -60,7 +60,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitZookeeperTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             {{- if $zk := .Values.pulsar_metadata.userProvidedZookeepers }}
             export PULSAR_MEM="-Xmx128M";
             until timeout 15 bin/pulsar zookeeper-shell -server {{ $zk }} ls {{ or .Values.metadataPrefix "/" }}; do
@@ -79,7 +79,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitOxiaTimeout }}", "sh", "-c"]
         args:
-          - >-
+          - |
             until nslookup {{ template "pulsar.oxia.server.service" . }}; do
               sleep 3;
             done;
@@ -93,7 +93,7 @@ spec:
         resources: {{ toYaml .Values.initContainer.resources | nindent 10 }}
         command: ["timeout", "{{ .Values.pulsar_metadata.waitBookkeeperTimeout }}", "sh", "-c"]
         args:
-        - >-
+        - |
           bin/apply-config-from-env.py conf/bookkeeper.conf;
           echo Default BOOKIE_MEM settings are set very high, which can cause the init container to fail.;
           echo Setting the memory to a lower value to avoid OOM as operations below are not memory intensive.;

--- a/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager-cluster-initialize.yaml
@@ -64,7 +64,7 @@ spec:
           resources: {{ toYaml .Values.initContainer.resources | nindent 12 }}
           command: [ "sh", "-c" ]
           args:
-            - >-
+            - |
               set -e;
               brokerServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.broker.component }} | grep Name | wc -l)";
               until [ ${brokerServiceNumber} -ge 1 ]; do

--- a/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset-statefulset.yaml
@@ -82,7 +82,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.toolset.additionalCommand }}
           {{ .Values.toolset.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
       {{- end }}
         command: ["sh", "-c"]
         args:
-        - >
+        - |
         {{- if .Values.zookeeper.additionalCommand }}
           {{ .Values.zookeeper.additionalCommand }}
         {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -21,9 +21,14 @@
 ### K8S Settings
 ###
 
-### Namespace to deploy pulsar
-# The namespace to use to deploy the pulsar components, if left empty
-# will default to .Release.Namespace (aka helm --namespace).
+### Namespace to deploy Pulsar
+### Note: Prefer using helm's --namespace flag with --create-namespace instead
+## The namespace to use to deploy the Pulsar components. If left empty,
+## it will default to .Release.Namespace (aka helm --namespace).
+## Please note that kube-prometheus-stack will not be able to scrape Pulsar component metrics by default unless
+## it is deployed in the same namespace as Pulsar. The kube-prometheus-stack namespace can be configured by setting
+## the kube-prometheus-stack.namespaceOverride key to match Pulsar's namespace.
+## More details are provided in the comments for the kube-prometheus-stack.namespaceOverride key later in this file.
 namespace: ""
 namespaceCreate: false
 
@@ -35,6 +40,7 @@ clusterDomain: cluster.local
 ###
 
 ## Set to true on install
+## There's no need to set this value unless you're using a system that doesn't track .Release.IsInstall or .Release.IsUpgrade (like argocd)
 initialize: false
 ## Set useReleaseStatus to false if you're deploying this chart using a system that doesn't track .Release.IsInstall or .Release.IsUpgrade (like argocd)
 useReleaseStatus: true
@@ -90,9 +96,8 @@ volumes:
 
 rbac:
   enabled: false
-  psp: false
+  psp: false  # DEPRECATED: PodSecurityPolicy is not supported in Kubernetes 1.25+
   limit_to_namespace: true
-
 
 ## AntiAffinity
 ##
@@ -101,6 +106,8 @@ rbac:
 ## If you need to disable AntiAffinity for a component, you can set
 ## the `affinity.anti_affinity` settings to `false` for that component.
 affinity:
+  ## When set to true, the scheduler will try to spread pods across different nodes.
+  ## It is necessary to set this to false if you're using a Kubernetes cluster with less than 3 nodes, such as local development environments.
   anti_affinity: true
   # Set the anti affinity type. Valid values:
   # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
@@ -1318,8 +1325,48 @@ proxy:
       http: 8080
       https: 8443
   service:
-    annotations: {}
-    type: LoadBalancer
+    # Service type defaults to ClusterIP for security reasons.
+    #
+    # SECURITY NOTICE: The Pulsar proxy is not designed for direct public internet exposure
+    # (see https://pulsar.apache.org/docs/4.0.x/administration-proxy/).
+    #
+    # If you need to expose the proxy outside of the cluster using a LoadBalancer service type:
+    # 1. Set type to LoadBalancer only in secured environments with proper network controls.
+    #    In cloud managed Kubernetes clusters, make sure to add annotations to the service to create an
+    #    internal load balancer so that the load balancer is not exposed to the public internet.
+    #    You must also ensure that the configuration is correct so that the load balancer is not exposed to the public internet.
+    # 2. Configure authentication and authorization
+    # 3. Use TLS for all connections
+    # 4. If you are exposing to unsecure networks, implement additional security measures like
+    #    IP restrictions (loadBalancerSourceRanges)
+    #
+    # Please notice that the the Apache Pulsar project takes no responsibility for any security issues
+    # for your deployment. Exposing the cluster using Pulsar Proxy to unsecure networks is not supported.
+    #
+    # Previous chart versions defaulted to LoadBalancer which could create security risks.
+    type: ClusterIP
+    # When using a LoadBalancer service type, add internal load balancer annotations to the service to create an internal load balancer.
+    annotations: {
+      ## Set internal load balancer annotations when using a LoadBalancer service type because of security reasons.
+      ## You must also ensure that the configuration is correct so that the load balancer is not exposed to the public internet.
+      ## This information below is for reference only and may not be applicable to your cloud provider.
+      ## Please refer to the cloud provider's documentation for the correct annotations.
+      ## Kubernetes documentation about internal load balancers
+      ## https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+      ## AWS / EKS
+      ## Ensure that you have recent AWS Load Balancer Controller installed.
+      ## Docs: https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/service/annotations/
+      # service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      ## Azure / AKS
+      ## Docs: https://learn.microsoft.com/en-us/azure/aks/internal-lb
+      # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      ## GCP / GKE
+      ## Docs: https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters
+      # networking.gke.io/load-balancer-type: "Internal"
+      ## Allow global access to the internal load balancer when needed.
+      # networking.gke.io/internal-load-balancer-allow-global-access: "true"
+    }
+
     ## Optional. Leave it blank to get next available random IP.
     loadBalancerIP: ""
     ## Set external traffic policy to: "Local" to preserve source IP on providers supporting it.
@@ -1419,6 +1466,12 @@ toolset:
 kube-prometheus-stack:
   ## Enable the kube-prometheus-stack chart
   enabled: true
+  ## This applies to deployments which don't use helm's --namespace flag to set the namespace.
+  ## If Pulsar's namespace is manually set using the `namespace` key, this setting should match the same namespace,
+  ## otherwise Prometheus will not be able to scrape the Pulsar metrics due to RBAC restrictions.
+  ## See https://prometheus-operator.dev/kube-prometheus/kube/monitoring-other-namespaces/ if you need to install
+  ## kube-prometheus-stack in a different namespace than Pulsar.
+  # namespaceOverride: ""
   ## Manages Prometheus and Alertmanager components
   prometheusOperator:
     enabled: true

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -912,6 +912,7 @@ pulsar_metadata:
     ## This is a global setting that applies to all BookKeeper components.
     ## When set to true, BookKeeper components will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
     ## When set to false, BookKeeper components will use BookKeeper's default ZooKeeper connection implementation.
+    ## Warning: Do not enable this feature unless you are aware of the risks and have tested it in non-production environments.
     usePulsarMetadataBookieDriver: false
 
     ## The session timeout for the metadata store in milliseconds. This setting is mapped to `zkTimeout` in `bookkeeper.conf`.

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,6 +728,10 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
+  ## Use RocksDB config in configData
+  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
+  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
+  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1378,9 +1378,15 @@ toolset:
 ## https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack
 ## For sample values, please see their documentation.
 kube-prometheus-stack:
+  ## Enable the kube-prometheus-stack chart
   enabled: true
+  ## Manages Prometheus and Alertmanager components
+  prometheusOperator:
+    enabled: true
+  ## Prometheus component
   prometheus:
     enabled: true
+  ## Grafana component
   grafana:
     enabled: true
     # Use random password at installation time for Grafana by default by setting empty value to `adminPassword`.
@@ -1451,10 +1457,15 @@ kube-prometheus-stack:
         zookeeper:
           url: https://raw.githubusercontent.com/streamnative/apache-pulsar-grafana-dashboard/master/dashboards.kubernetes/zookeeper-3.6.json
           datasource: Prometheus
+        offloader:
+          url: https://raw.githubusercontent.com/apache/pulsar/refs/heads/master/grafana/dashboards/offloader.json
+          datasource: Prometheus
+  ## Prometheus node exporter component
   prometheus-node-exporter:
     enabled: true
     hostRootFsMount:
       enabled: false
+  ## Alertmanager component
   alertmanager:
     enabled: false
 

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -728,10 +728,6 @@ bookkeeper:
   ## templates/bookkeeper-service-account.yaml
   service_account:
     annotations: {}
-  ## Use RocksDB config in configData
-  ## Use dbStorage_rocksDB_* / PULSAR_PREFIX_dbStorage_rocksDB_* settings defined in configData instead of conf/*_rocksdb.conf files in the Pulsar docker image
-  ## See https://github.com/apache/bookkeeper/pull/3523 as reference
-  useRocksDBConfigInConfigData: true
   ## Bookkeeper configmap
   ## templates/bookkeeper-configmap.yaml
   ##

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -880,6 +880,44 @@ pulsar_metadata:
   ## Timeout for running metadata initialization
   initTimeout: 60
 
+  ## Allow read-only operations on the metadata store when the metadata store is not available.
+  ## This is useful when you want to continue serving requests even if the metadata store is not fully available with quorum.
+  metadataStoreAllowReadOnlyOperations: false
+
+  ## The session timeout for the metadata store in milliseconds.
+  metadataStoreSessionTimeoutMillis: 30000
+
+  ## Metadata store operation timeout in seconds.
+  metadataStoreOperationTimeoutSeconds: 30
+
+  ## The expiry time for the metadata store cache in seconds.
+  metadataStoreCacheExpirySeconds: 300
+
+  ## Whether we should enable metadata operations batching
+  metadataStoreBatchingEnabled: true
+
+  ## Maximum delay to impose on batching grouping (in milliseconds)
+  metadataStoreBatchingMaxDelayMillis: 5
+
+  ## Maximum number of operations to include in a singular batch
+  metadataStoreBatchingMaxOperations: 1000
+
+  ## Maximum size of a batch (in KB)
+  metadataStoreBatchingMaxSizeKb: 128
+
+  ## BookKeeper metadata configuration settings with Pulsar Helm Chart deployments
+  bookkeeper:
+    ## Controls whether to use the PIP-45 metadata driver (PulsarMetadataBookieDriver) for BookKeeper components
+    ## when using ZooKeeper as a metadata store.
+    ## This is a global setting that applies to all BookKeeper components.
+    ## When set to true, BookKeeper components will use the PIP-45 metadata driver (PulsarMetadataBookieDriver).
+    ## When set to false, BookKeeper components will use BookKeeper's default ZooKeeper connection implementation.
+    usePulsarMetadataBookieDriver: false
+
+    ## The session timeout for the metadata store in milliseconds. This setting is mapped to `zkTimeout` in `bookkeeper.conf`.
+    ## due to implementation details in the PulsarMetadataBookieDriver, it also applies when Oxia metadata store is enabled.
+    metadataStoreSessionTimeoutMillis: 30000
+
   # resources for bin/pulsar initialize-cluster-metadata
   resources:
 #    requests:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1498,6 +1498,12 @@ kube-prometheus-stack:
         offloader:
           url: https://raw.githubusercontent.com/apache/pulsar/refs/heads/master/grafana/dashboards/offloader.json
           datasource: Prometheus
+        broker-cache:
+          url: https://raw.githubusercontent.com/datastax/pulsar-helm-chart/refs/heads/master/helm-chart-sources/pulsar/grafana-dashboards/broker-cache-by-broker.json
+          datasource: Prometheus
+        sockets:
+          url: https://raw.githubusercontent.com/datastax/pulsar-helm-chart/refs/heads/master/helm-chart-sources/pulsar/grafana-dashboards/sockets.json
+          datasource: Prometheus
   ## Prometheus node exporter component
   prometheus-node-exporter:
     enabled: true

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -25,7 +25,7 @@ set -e
 NAMESPACE=cert-manager
 NAME=cert-manager
 # check compatibility with k8s versions from https://cert-manager.io/docs/installation/supported-releases/
-VERSION=v1.12.13
+VERSION=v1.12.16
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."

--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -18,34 +18,13 @@
 # under the License.
 #
 
-if [ -z "$CHART_HOME" ]; then
-    echo "error: CHART_HOME should be initialized"
-    exit 1
+if [ -z "$PULSAR_VERSION" ]; then
+    if command -v yq &> /dev/null; then
+        # use yq to get the appVersion from the Chart.yaml file
+        PULSAR_VERSION=$(yq .appVersion charts/pulsar/Chart.yaml)
+    else
+        # use a default version if yq is not installed
+        PULSAR_VERSION="4.0.3"
+    fi
 fi
-
-OUTPUT=${CHART_HOME}/output
-OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v3.0.2.6
-PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
-export PATH=${HOME}/.pulsarctl/plugins:${PATH}
-
-test -d "$OUTPUT_BIN" || mkdir -p "$OUTPUT_BIN"
-
-function pulsar::verify_pulsarctl() {
-    if test -x "$PULSARCTL_BIN"; then
-        return
-    fi
-    return 1
-}
-
-function pulsar::ensure_pulsarctl() {
-    if pulsar::verify_pulsarctl; then
-        return 0
-    fi
-    echo "Get pulsarctl install.sh script ..."
-    install_script=$(mktemp)
-    trap "test -f $install_script && rm $install_script" RETURN
-    curl --retry 10 -L -o $install_script https://raw.githubusercontent.com/streamnative/pulsarctl/master/install.sh
-    chmod +x $install_script
-    $install_script --user --version ${PULSARCTL_VERSION}
-}
+PULSAR_TOKENS_CONTAINER_IMAGE="apachepulsar/pulsar:${PULSAR_VERSION}"

--- a/scripts/pulsar/get_token.sh
+++ b/scripts/pulsar/get_token.sh
@@ -74,10 +74,6 @@ if [[ "x${role}" == "x" ]]; then
     exit 1
 fi
 
-source ${CHART_HOME}/scripts/pulsar/common_auth.sh
-
-pulsar::ensure_pulsarctl
-
 namespace=${namespace:-pulsar}
 release=${release:-pulsar-dev}
 


### PR DESCRIPTION
- **Improve kube-prometheus-stack config in values.yaml by adding missing key and some basic comments (#579)**
- **Restore support for dbStorage_rocksDB_* settings defined in bookkeeper.configData (#580)**
- **Upgrade default cert-manager version to 1.12.16 (#581)**
- **Replace ">" with "|" to avoid Go Yaml issue go-yaml/yaml#789 (#582)**
- **Revisit solution to configure Bookkeeper RocksDB settings - default to individual config files (#583)**
- **Remove the dependency to pulsarctl when generating JWT tokens (#584)**
- **Use PIP-45 metadata store config to replace deprecated ZK config and make PulsarMetadataBookieDriver configurable in BK (#576)**
- **Update RELEASE.md**
- **Use BookKeeper BP-29 metadataServiceUri to configure bookie metadata store, also when using Zookeeper (#585)**
- **Add Broker Cache and Sockets dashboards (#586)**
- **Add comment warning about enabling PulsarMetadataBookieDriver**
- **Change Pulsar Proxy service load balancer type to ClusterIP**
